### PR TITLE
add maxReachedStep to EasyStepper and isAlreadyReached to BaseStep

### DIFF
--- a/lib/easy_stepper.dart
+++ b/lib/easy_stepper.dart
@@ -87,6 +87,9 @@ class EasyStepper extends StatefulWidget {
   /// The index of currently active step.
   final int activeStep;
 
+  /// The index of highest reached step
+  final int? maxReachedStep;
+
   /// Whether show step title or not.
   final bool showTitle;
 
@@ -158,6 +161,7 @@ class EasyStepper extends StatefulWidget {
     Key? key,
     required this.activeStep,
     required this.steps,
+    this.maxReachedStep,
     this.lineType = LineType.dotted,
     this.enableStepTapping = true,
     this.direction = Axis.horizontal,
@@ -323,6 +327,7 @@ class _EasyStepperState extends State<EasyStepper> {
       isActive: index == widget.activeStep,
       isFinished: index < widget.activeStep,
       isUnreached: index > widget.activeStep,
+      isAlreadyReached: widget.maxReachedStep != null ? index <= widget.maxReachedStep! : false,
       activeStepBackgroundColor: widget.activeStepBackgroundColor,
       activeStepBorderColor: widget.activeStepBorderColor,
       activeTextColor: widget.activeStepTextColor,

--- a/lib/src/core/base_step.dart
+++ b/lib/src/core/base_step.dart
@@ -16,6 +16,7 @@ class BaseStep extends StatelessWidget {
     required this.isActive,
     required this.isFinished,
     required this.isUnreached,
+    required this.isAlreadyReached,
     required this.onStepSelected,
     required this.showTitle,
     required this.radius,
@@ -48,6 +49,7 @@ class BaseStep extends StatelessWidget {
   final bool isActive;
   final bool isFinished;
   final bool isUnreached;
+  final bool isAlreadyReached;
   final VoidCallback? onStepSelected;
   final double radius;
   final bool showTitle;
@@ -111,12 +113,7 @@ class BaseStep extends StatelessWidget {
                     borderRadius: stepShape != StepShape.circle
                         ? BorderRadius.circular(stepRadius ?? 0)
                         : null,
-                    color: isFinished
-                        ? finishedBackgroundColor ??
-                            Theme.of(context).colorScheme.primary
-                        : isActive
-                            ? activeStepBackgroundColor ?? Colors.transparent
-                            : unreachedBackgroundColor ?? Colors.transparent,
+                      color: _handleColor(context, isFinished, isActive, isAlreadyReached)
                   ),
                   alignment: Alignment.center,
                   child: showStepBorder
@@ -127,13 +124,7 @@ class BaseStep extends StatelessWidget {
                           radius: stepShape != StepShape.circle
                               ? Radius.circular(stepRadius ?? 0)
                               : const Radius.circular(0),
-                          color: isActive
-                              ? activeStepBorderColor ??
-                                  Theme.of(context).colorScheme.primary
-                              : isFinished
-                                  ? finishedBorderColor ?? Colors.transparent
-                                  : unreachedBorderColor ??
-                                      Colors.grey.shade400,
+                          color: _handleBorderColor(context, isFinished, isActive, isAlreadyReached),
                           strokeWidth: borderThickness,
                           dashPattern: borderType == BorderType.normal
                               ? [1, 0]
@@ -153,6 +144,37 @@ class BaseStep extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Color _handleColor(BuildContext context, bool isFinished, bool isActive, bool isAlreadyReached)  {
+    if (isActive) {
+      return activeStepBackgroundColor ?? Colors.transparent;
+    } else {
+      if(isFinished) {
+        return finishedBackgroundColor ??
+            Theme.of(context).colorScheme.primary;
+      } else if(isAlreadyReached) {
+        return finishedBackgroundColor ??
+            Theme.of(context).colorScheme.primary;
+      } else {
+        return unreachedBackgroundColor ?? Colors.transparent;
+      }
+    }
+  }
+
+  Color _handleBorderColor(BuildContext context, bool isFinished, bool isActive, bool isAlreadyReached) {
+    if (isActive) {
+      return activeStepBorderColor ?? Theme.of(context).colorScheme.primary;
+    } else {
+      if(isFinished) {
+        return finishedBorderColor ?? Colors.transparent;
+      } else if(isAlreadyReached) {
+        return finishedBorderColor ?? Colors.transparent;
+      } else {
+        return unreachedBorderColor ??
+            Colors.grey.shade400;
+      }
+    }
   }
 
   Widget _buildStepTitle(BuildContext context) {


### PR DESCRIPTION
Description:  To navigate directly only between the already reached steps. The steps that have not yet been reached cannot be reached by clicking on the step. Only by indirectly changing the "activeStep" e.g. via external forward and back buttons