### PR TITLE
Fixed multiline step title display

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -404,7 +404,7 @@ class _MyAppState extends State<MyApp> {
                 ),
                 const SizedBox(height: 20),
                 Container(
-                  padding: const EdgeInsets.symmetric(vertical: 40),
+                  padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 35),
                   color: Colors.grey.shade200,
                   clipBehavior: Clip.none,
                   child: EasyStepper(
@@ -425,67 +425,135 @@ class _MyAppState extends State<MyApp> {
                     showStepBorder: false,
                     steps: [
                       EasyStep(
-                        customStep: CircleAvatar(
-                          radius: 8,
-                          backgroundColor: Colors.white,
-                          child: CircleAvatar(
-                            radius: 7,
-                            backgroundColor:
-                                activeStep >= 0 ? Colors.orange : Colors.white,
+                          enabled: 0 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 0 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                        title: 'Waiting',
+                          topTitle: 0 % 2 == 1,
+                          title: "Awaiting authorization",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Awaiting authorization", textAlign: TextAlign.center),
+                          )
                       ),
                       EasyStep(
-                        customStep: CircleAvatar(
-                          radius: 8,
-                          backgroundColor: Colors.white,
-                          child: CircleAvatar(
-                            radius: 7,
-                            backgroundColor:
-                                activeStep >= 1 ? Colors.orange : Colors.white,
+                          enabled: 1 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 1 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                        title: 'Order Received',
-                        topTitle: true,
+                          topTitle: 1 % 2 == 1,
+                          title: "Authorized",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Authorized", textAlign: TextAlign.center),
+                          )
                       ),
                       EasyStep(
-                        customStep: CircleAvatar(
-                          radius: 8,
-                          backgroundColor: Colors.white,
-                          child: CircleAvatar(
-                            radius: 7,
-                            backgroundColor:
-                                activeStep >= 2 ? Colors.orange : Colors.white,
+                          enabled: 2 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 2 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                        title: 'Preparing',
+                          topTitle: 2 % 2 == 1,
+                          title: "Received",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Received", textAlign: TextAlign.center),
+                          )
                       ),
                       EasyStep(
-                        customStep: CircleAvatar(
-                          radius: 8,
-                          backgroundColor: Colors.white,
-                          child: CircleAvatar(
-                            radius: 7,
-                            backgroundColor:
-                                activeStep >= 3 ? Colors.orange : Colors.white,
+                          enabled: 3 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 3 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                        title: 'On Way',
-                        topTitle: true,
+                          topTitle: 3 % 2 == 1,
+                          title: "Under processing",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Under processing", textAlign: TextAlign.center),
+                          )
                       ),
                       EasyStep(
-                        customStep: CircleAvatar(
-                          radius: 8,
-                          backgroundColor: Colors.white,
-                          child: CircleAvatar(
-                            radius: 7,
-                            backgroundColor:
-                                activeStep >= 4 ? Colors.orange : Colors.white,
+                          enabled: 4 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 4 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
-                        ),
-                        title: 'Delivered',
+                          topTitle: 4 % 2 == 1,
+                          title: "Awaiting customer approval",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Awaiting customer approval", textAlign: TextAlign.center),
+                          )
                       ),
+                      EasyStep(
+                          enabled: 5 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 5 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          topTitle: 5 % 2 == 1,
+                          title: "Approved by customer personally",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Approved by customer personally", textAlign: TextAlign.center),
+                          )
+                      ),
+                      EasyStep(
+                          enabled: 6 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 6 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          topTitle: 6 % 2 == 1,
+                          title: "Confirmed",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Confirmed", textAlign: TextAlign.center),
+                          )
+                      ),
+                      EasyStep(
+                          enabled: 7 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 7 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          topTitle: 7 % 2 == 1,
+                          title: "In preparation",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("In preparation", textAlign: TextAlign.center),
+                          )
+                      ),
+                      EasyStep(
+                          enabled: 8 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 8 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          topTitle: 8 % 2 == 1,
+                          title: "Shipped",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Shipped", textAlign: TextAlign.center),
+                          )
+                      ),
+                      EasyStep(
+                          enabled: 9 <= activeStep + 1,
+                          customStep: CircleAvatar(
+                            radius: 8,
+                            backgroundColor: 9 <= activeStep ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          topTitle: 9 % 2 == 1,
+                          title: "Delivered",
+                          customTitle: const SizedBox(
+                            width: double.infinity,
+                            child: Text("Delivered", textAlign: TextAlign.center),
+                          )
+                      )
                     ],
                     onStepReached: (index) =>
                         setState(() => activeStep = index),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -419,6 +419,7 @@ class _MyAppState extends State<MyApp> {
                     ),
                     activeStepTextColor: Colors.black87,
                     finishedStepTextColor: Colors.black87,
+                    titlesAreLargerThanSteps: true,
                     internalPadding: 0,
                     showLoadingAnimation: false,
                     stepRadius: 8,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,7 +79,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.2"
+    version: "0.8.3"
   fake_async:
     dependency: transitive
     description:

--- a/lib/easy_stepper.dart
+++ b/lib/easy_stepper.dart
@@ -98,7 +98,7 @@ class EasyStepper extends StatefulWidget {
   final double internalPadding;
 
   /// The amount of padding around the stepper.
-  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? padding;
 
   /// The curve of the animation to show when a step is reached.
   final Curve stepAnimationCurve;
@@ -171,12 +171,7 @@ class EasyStepper extends StatefulWidget {
     this.alignment = Alignment.center,
     this.fitWidth = true,
     this.showScrollbar = true,
-    this.padding = const EdgeInsetsDirectional.only(
-      start: 10,
-      end: 10,
-      top: 10,
-      bottom: 10,
-    ),
+    this.padding,
     this.internalPadding = 8,
     this.stepAnimationCurve = Curves.linear,
     this.stepAnimationDuration = const Duration(seconds: 1),
@@ -205,12 +200,27 @@ class _EasyStepperState extends State<EasyStepper> {
   ScrollController? _scrollController;
   late int _selectedIndex;
   late LineStyle lineStyle;
+  late EdgeInsetsGeometry _padding;
 
   @override
   void initState() {
     lineStyle = widget.lineStyle ?? const LineStyle();
     _selectedIndex = widget.activeStep;
     _scrollController = ScrollController();
+
+    _padding = const EdgeInsetsDirectional.all(10);
+    if(widget.direction == Axis.horizontal){
+      if(widget.steps.any((element) => element.topTitle)){
+        _padding = _padding.add(const EdgeInsetsDirectional.only(top: 45));
+      }
+      if(!widget.disableScroll && widget.showScrollbar){
+        _padding = _padding.add(const EdgeInsetsDirectional.only(bottom: 15));
+      }
+    }
+    if(widget.padding != null){
+      _padding.add(widget.padding!);
+    }
+
     super.initState();
   }
 
@@ -286,8 +296,9 @@ class _EasyStepperState extends State<EasyStepper> {
                       child: SingleChildScrollView(
                         scrollDirection: widget.direction,
                         physics: const ClampingScrollPhysics(),
+                        clipBehavior: Clip.none,
                         controller: _scrollController,
-                        padding: widget.padding,
+                        padding: _padding,
                         child: widget.direction == Axis.horizontal
                             ? Row(
                                 mainAxisSize: MainAxisSize.min,
@@ -302,8 +313,9 @@ class _EasyStepperState extends State<EasyStepper> {
                   : SingleChildScrollView(
                       scrollDirection: widget.direction,
                       physics: const ClampingScrollPhysics(),
+                      clipBehavior: Clip.none,
                       controller: _scrollController,
-                      padding: widget.padding,
+                      padding: _padding,
                       child: widget.direction == Axis.horizontal
                           ? Row(
                               mainAxisSize: MainAxisSize.min,
@@ -322,18 +334,13 @@ class _EasyStepperState extends State<EasyStepper> {
   List<Widget> _buildEasySteps() {
     return List.generate(widget.steps.length, (index) {
       return widget.direction == Axis.horizontal
-          ? Padding(
-              padding: widget.steps.any((element) => element.topTitle)
-                  ? const EdgeInsets.only(top: 10)
-                  : EdgeInsets.zero,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  _buildStep(index),
-                  _buildLine(index, Axis.horizontal),
-                ],
-              ),
-            )
+          ? Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _buildStep(index),
+              _buildLine(index, Axis.horizontal),
+            ],
+          )
           : Column(
               children: <Widget>[
                 _buildStep(index),
@@ -375,7 +382,7 @@ class _EasyStepperState extends State<EasyStepper> {
       unreachedIconColor: widget.unreachedStepIconColor,
       lottieAnimation: widget.loadingAnimation,
       padding: max(widget.internalPadding,
-          (widget.direction == Axis.vertical ? widget.padding.horizontal : 0)),
+          (widget.direction == Axis.vertical ? _padding.horizontal : 0)),
       stepShape: widget.stepShape,
       stepRadius: widget.stepBorderRadius,
       borderType: _handleBorderType(index),

--- a/lib/easy_stepper.dart
+++ b/lib/easy_stepper.dart
@@ -100,6 +100,11 @@ class EasyStepper extends StatefulWidget {
   /// The amount of padding around the stepper.
   final EdgeInsetsGeometry? padding;
 
+  ///Set this to true if the titles (of at least the first or last step) are wider
+  ///than the step itself. This will allow the stepper to correctly pad them so that
+  ///the titles don't get cut off
+  final bool titlesAreLargerThanSteps;
+
   /// The curve of the animation to show when a step is reached.
   final Curve stepAnimationCurve;
 
@@ -172,6 +177,7 @@ class EasyStepper extends StatefulWidget {
     this.fitWidth = true,
     this.showScrollbar = true,
     this.padding,
+    this.titlesAreLargerThanSteps = false,
     this.internalPadding = 8,
     this.stepAnimationCurve = Curves.linear,
     this.stepAnimationDuration = const Duration(seconds: 1),
@@ -212,6 +218,9 @@ class _EasyStepperState extends State<EasyStepper> {
     if(widget.direction == Axis.horizontal){
       if(widget.steps.any((element) => element.topTitle)){
         _padding = _padding.add(const EdgeInsetsDirectional.only(top: 45));
+      }
+      if(widget.titlesAreLargerThanSteps){
+        _padding = _padding.add(EdgeInsetsDirectional.symmetric(horizontal: lineStyle.lineLength / 2));
       }
       if(!widget.disableScroll && widget.showScrollbar){
         _padding = _padding.add(const EdgeInsetsDirectional.only(bottom: 15));
@@ -296,7 +305,6 @@ class _EasyStepperState extends State<EasyStepper> {
                       child: SingleChildScrollView(
                         scrollDirection: widget.direction,
                         physics: const ClampingScrollPhysics(),
-                        clipBehavior: Clip.none,
                         controller: _scrollController,
                         padding: _padding,
                         child: widget.direction == Axis.horizontal
@@ -313,7 +321,6 @@ class _EasyStepperState extends State<EasyStepper> {
                   : SingleChildScrollView(
                       scrollDirection: widget.direction,
                       physics: const ClampingScrollPhysics(),
-                      clipBehavior: Clip.none,
                       controller: _scrollController,
                       padding: _padding,
                       child: widget.direction == Axis.horizontal

--- a/lib/src/core/base_step.dart
+++ b/lib/src/core/base_step.dart
@@ -3,6 +3,8 @@ import 'package:easy_stepper/src/core/easy_border.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 
+import 'base_step_delegate.dart';
+
 /// Callback is fired when a step is reached.
 typedef OnStepReached = void Function(int index);
 
@@ -93,63 +95,64 @@ class BaseStep extends StatelessWidget {
       child: InkWell(
         onTap: enabled ? onStepSelected : null,
         canRequestFocus: false,
-        child: Stack(
-          clipBehavior: Clip.none,
-          textDirection: textDirection,
-          alignment: Alignment.topCenter,
+        child: CustomMultiChildLayout(
+          delegate: BaseStepDelegate(stepRadius: radius, topTitle: step.topTitle, direction: direction),
           children: [
-            Material(
-              color: Colors.transparent,
-              shape:
-                  stepShape == StepShape.circle ? const CircleBorder() : null,
-              clipBehavior: Clip.antiAlias,
-              borderRadius: stepShape != StepShape.circle
-                  ? BorderRadius.circular(stepRadius ?? 0)
-                  : null,
-              child: InkWell(
-                onTap: enabled ? onStepSelected : null,
-                canRequestFocus: false,
-                radius: radius,
-                child: Container(
-                  width: radius * 2,
-                  height: radius * 2,
-                  decoration: BoxDecoration(
-                      shape: stepShape == StepShape.circle
-                          ? BoxShape.circle
-                          : BoxShape.rectangle,
-                      borderRadius: stepShape != StepShape.circle
-                          ? BorderRadius.circular(stepRadius ?? 0)
-                          : null,
-                      color: _handleColor(
-                          context, isFinished, isActive, isAlreadyReached)),
-                  alignment: Alignment.center,
-                  child: showStepBorder
-                      ? EasyBorder(
-                          borderShape: stepShape == StepShape.circle
-                              ? BorderShape.Circle
-                              : BorderShape.RRect,
-                          radius: stepShape != StepShape.circle
-                              ? Radius.circular(stepRadius ?? 0)
-                              : const Radius.circular(0),
-                          color: _handleBorderColor(
-                              context, isFinished, isActive, isAlreadyReached),
-                          strokeWidth: borderThickness,
-                          dashPattern: borderType == BorderType.normal
-                              ? [1, 0]
-                              : dashPattern,
-                          child: isActive && showLoadingAnimation
-                              ? _buildLoadingIcon()
-                              : _buildIcon(context),
-                        )
-                      : isActive && showLoadingAnimation
+            LayoutId(
+              id: BaseStepElem.step,
+              child: Material(
+                color: Colors.transparent,
+                shape:
+                stepShape == StepShape.circle ? const CircleBorder() : null,
+                clipBehavior: Clip.antiAlias,
+                borderRadius: stepShape != StepShape.circle
+                    ? BorderRadius.circular(stepRadius ?? 0)
+                    : null,
+                child: InkWell(
+                  onTap: enabled ? onStepSelected : null,
+                  canRequestFocus: false,
+                  radius: radius,
+                  child: Container(
+                    width: radius * 2,
+                    height: radius * 2,
+                    decoration: BoxDecoration(
+                        shape: stepShape == StepShape.circle
+                            ? BoxShape.circle
+                            : BoxShape.rectangle,
+                        borderRadius: stepShape != StepShape.circle
+                            ? BorderRadius.circular(stepRadius ?? 0)
+                            : null,
+                        color: _handleColor(
+                            context, isFinished, isActive, isAlreadyReached)),
+                    alignment: Alignment.center,
+                    child: showStepBorder
+                        ? EasyBorder(
+                      borderShape: stepShape == StepShape.circle
+                          ? BorderShape.Circle
+                          : BorderShape.RRect,
+                      radius: stepShape != StepShape.circle
+                          ? Radius.circular(stepRadius ?? 0)
+                          : const Radius.circular(0),
+                      color: _handleBorderColor(
+                          context, isFinished, isActive, isAlreadyReached),
+                      strokeWidth: borderThickness,
+                      dashPattern: borderType == BorderType.normal
+                          ? [1, 0]
+                          : dashPattern,
+                      child: isActive && showLoadingAnimation
                           ? _buildLoadingIcon()
                           : _buildIcon(context),
+                    )
+                        : isActive && showLoadingAnimation
+                        ? _buildLoadingIcon()
+                        : _buildIcon(context),
+                  ),
                 ),
-              ),
+              )
             ),
-            if (showTitle) _buildStepTitle(context),
+            if(showTitle) LayoutId(id: BaseStepElem.title, child: _buildStepTitle(context))
           ],
-        ),
+        )
       ),
     );
   }
@@ -215,28 +218,24 @@ class BaseStep extends StatelessWidget {
   }
 
   Widget _buildStepTitle(BuildContext context) {
-    return Positioned.directional(
-      textDirection: textDirection,
-      top: step.topTitle ? -(radius * 2.35) : (radius * 2.35),
-      child: SizedBox(
-        width: (radius * 2) +
-            (padding ?? 0) +
-            (direction == Axis.horizontal ? lineLength : 0),
-        child: step.customTitle ??
-            Text(
-              step.title ?? '',
-              maxLines: 3,
-              textAlign: TextAlign.center,
-              softWrap: false,
-              overflow: TextOverflow.visible,
-              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                    color: _handleTitleColor(
-                        context, isFinished, isActive, isAlreadyReached),
-                    height: 1,
-                    // fontSize: radius * 0.45,
-                  ),
+    return SizedBox(
+      width: (radius * 2) +
+          (padding ?? 0) +
+          (direction == Axis.horizontal ? lineLength : 0),
+      child: step.customTitle ??
+          Text(
+            step.title ?? '',
+            maxLines: 3,
+            textAlign: TextAlign.center,
+            softWrap: false,
+            overflow: TextOverflow.visible,
+            style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+              color: _handleTitleColor(
+                  context, isFinished, isActive, isAlreadyReached),
+              height: 1,
+              // fontSize: radius * 0.45,
             ),
-      ),
+          ),
     );
   }
 

--- a/lib/src/core/base_step_delegate.dart
+++ b/lib/src/core/base_step_delegate.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+enum BaseStepElem{
+  step,
+  title
+}
+
+class BaseStepDelegate extends MultiChildLayoutDelegate{
+  final double stepRadius;
+  final Axis direction;
+  final bool topTitle;
+
+  BaseStepDelegate({
+    required this.stepRadius,
+    required this.direction,
+    this.topTitle = false,
+  });
+
+  @override
+  void performLayout(Size size) {
+    assert(hasChild(BaseStepElem.step));
+
+    layoutChild(
+      BaseStepElem.step,
+      BoxConstraints.loose(size), // This just says that the child cannot be bigger than the whole layout.
+    );
+
+    positionChild(
+        BaseStepElem.step,
+        Offset((size.width - 2 * stepRadius) / 2, direction == Axis.horizontal ? 0 : (size.height - 2 * stepRadius) / 2)
+    );
+
+    if(hasChild(BaseStepElem.title)){
+      final Size titleSize = layoutChild(
+        BaseStepElem.title,
+        const BoxConstraints(),
+      );
+
+      Offset titleOffset = Offset(
+        - titleSize.width / 2 + (size.width / 2),
+        topTitle ? -(stepRadius + titleSize.height) : (stepRadius * 2.35)
+      );
+
+      positionChild(
+        BaseStepElem.title,
+        titleOffset
+      );
+    }
+  }
+
+  @override
+  bool shouldRelayout(BaseStepDelegate oldDelegate) {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixed bug where top step titles would get cut off if they were long and occupied more than one line.
 
Steps now correctly display titles even if these are very long and occupy more than one line.

Also adjusted padding so that the scrollbar does not cover the titles.

Added ```titlesAreLargerThanSteps``` property to EasyStepper, that allows the user to specify when the titles of the first or last step are wider than the actual step. If set to true EasyStepper will automatically pad the widget horizontally to prevent the titles from being cut off.

Updated example project to showcase this behavior.