### PR TITLE
Fix: Space Evenly Step & Title

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -154,7 +154,7 @@ class _MyAppState extends State<MyApp> {
                   child: Column(
                     children: [
                       Image.asset(
-                        dashImages[activeStep],
+                        dashImages[activeStep % dashImages.length],
                         height: 150,
                       ),
                       const SizedBox(height: 5),
@@ -608,42 +608,49 @@ class _MyAppState extends State<MyApp> {
                         unreachedStepBorderColor: Colors.black54,
                         finishedStepBackgroundColor: Colors.deepPurple,
                         unreachedStepBackgroundColor: Colors.deepOrange,
-                        showTitle: false,
+                        showTitle: true,
                         onStepReached: (index) =>
                             setState(() => activeStep = index),
                         steps: const [
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(CupertinoIcons.cart),
                             title: 'Cart',
                             activeIcon: Icon(CupertinoIcons.cart),
                             lineText: 'Cart Line',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.file_present),
                             activeIcon: Icon(Icons.file_present),
                             title: 'Address',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.filter_center_focus_sharp),
                             activeIcon: Icon(Icons.filter_center_focus_sharp),
                             title: 'Checkout',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.money),
                             activeIcon: Icon(Icons.money),
                             title: 'Payment',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.local_shipping_outlined),
                             activeIcon: Icon(Icons.local_shipping_outlined),
                             title: 'Shipping',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.file_copy_outlined),
                             activeIcon: Icon(Icons.file_copy_outlined),
                             title: 'Order Details',
                           ),
                           EasyStep(
+                            topTitle: true,
                             icon: Icon(Icons.check_circle_outline),
                             activeIcon: Icon(Icons.check_circle_outline),
                             title: 'Finish',
@@ -660,7 +667,7 @@ class _MyAppState extends State<MyApp> {
                         unreachedStepBorderColor: Colors.black54,
                         finishedStepBackgroundColor: Colors.deepPurple,
                         unreachedStepBackgroundColor: Colors.deepOrange,
-                        showTitle: false,
+                        showTitle: true,
                         onStepReached: (index) =>
                             setState(() => activeStep = index),
                         steps: const [

--- a/lib/src/core/base_step_delegate.dart
+++ b/lib/src/core/base_step_delegate.dart
@@ -30,21 +30,52 @@ class BaseStepDelegate extends MultiChildLayoutDelegate{
         Offset((size.width - 2 * stepRadius) / 2, direction == Axis.horizontal ? 0 : (size.height - 2 * stepRadius) / 2)
     );
 
-    if(hasChild(BaseStepElem.title)){
+    if (hasChild(BaseStepElem.title)) {
       final Size titleSize = layoutChild(
         BaseStepElem.title,
         const BoxConstraints(),
       );
 
-      Offset titleOffset = Offset(
-        - titleSize.width / 2 + (size.width / 2),
-        topTitle ? -(stepRadius + titleSize.height) : (stepRadius * 2.35)
-      );
+      if (direction == Axis.horizontal) {
+        Offset titleOffset = Offset(-titleSize.width / 2 + (size.width / 2),
+            topTitle ? -(stepRadius + titleSize.height) : (stepRadius * 2.35));
 
+        positionChild(BaseStepElem.title, titleOffset);
+      } else {
+        // Space evenly Step and Title
+        double stepY;
+        double titleY;
+
+        double spaceY = (size.height - stepRadius * 2 - titleSize.height) / 3;
+
+        if (topTitle) {
+          titleY = spaceY;
+          stepY = 2 * spaceY + titleSize.height;
+        } else {
+          stepY = spaceY;
+          titleY = 2 * (spaceY + stepRadius);
+        }
+
+        positionChild(
+          BaseStepElem.step,
+          Offset((size.width - 2 * stepRadius) / 2,
+              direction == Axis.horizontal ? 0 : stepY),
+        );
+
+        Offset titleOffset =
+            Offset(-titleSize.width / 2 + (size.width / 2), titleY);
+
+        positionChild(BaseStepElem.title, titleOffset);
+      }
+    } else {
+      // Position step in the middle
       positionChild(
-        BaseStepElem.title,
-        titleOffset
-      );
+          BaseStepElem.step,
+          Offset(
+              (size.width - 2 * stepRadius) / 2,
+              direction == Axis.horizontal
+                  ? 0
+                  : (size.height - 2 * stepRadius) / 2));
     }
   }
 


### PR DESCRIPTION
I have run example, on vertical stepper with `showTitle: true`, the text is above the step like this
![step_old](https://github.com/ma7moud3osman/easy_stepper/assets/106216782/a6837b1d-db4a-4911-b250-5261c2d61017)

I recalculated their positions so that they are evenly aligned.
In the example, I change 2 vertical stepper to show title, one below step and one is below the step
![step_new](https://github.com/ma7moud3osman/easy_stepper/assets/106216782/c6983d32-05ae-430b-bd61-8559141ebb71)
